### PR TITLE
Remove links to HOT's Facebook, YouTube, and Instagram

### DIFF
--- a/frontend/src/components/footer/index.js
+++ b/frontend/src/components/footer/index.js
@@ -4,10 +4,7 @@ import { Link, matchRoutes, useLocation } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import {
   TwitterIcon,
-  FacebookIcon,
-  YoutubeIcon,
   GithubIcon,
-  InstagramIcon,
   ExternalLinkIcon,
 } from '../svgIcons';
 import messages from '../messages';
@@ -15,18 +12,12 @@ import { getMenuItemsForUser } from '../header';
 import {
   ORG_TWITTER,
   ORG_GITHUB,
-  ORG_INSTAGRAM,
-  ORG_FB,
-  ORG_YOUTUBE,
   ORG_PRIVACY_POLICY_URL,
 } from '../../config';
 import './styles.scss';
 
 const socialNetworks = [
   { link: ORG_TWITTER, icon: <TwitterIcon style={{ height: '20px', width: '20px' }} noBg /> },
-  { link: ORG_FB, icon: <FacebookIcon style={{ height: '20px', width: '20px' }} /> },
-  { link: ORG_YOUTUBE, icon: <YoutubeIcon style={{ height: '20px', width: '20px' }} /> },
-  { link: ORG_INSTAGRAM, icon: <InstagramIcon style={{ height: '20px', width: '20px' }} /> },
   { link: ORG_GITHUB, icon: <GithubIcon style={{ height: '20px', width: '20px' }} /> },
 ];
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Addresses hotosm social links mentioned in https://github.com/OpenHistoricalMap/issues/issues/1097#issuecomment-3103605294

## Describe this PR

Removes all mention of those links.